### PR TITLE
Added postgresql db support to telemetry

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -304,10 +304,10 @@ You need to start the test with your replacements like this:
 w.postMessage('start {"url_dl": "newGarbageURL", "url_ul": "newEmptyURL", "url_ping": "newEmptyURL", "url_getIp": "newIpURL"}')
 ```
 ## Telemetry
-Telemetry currently requires PHP and either MySQL or SQLite.  
+Telemetry currently requires PHP and either MySQL, PostgreSQL or SQLite.
 To set up the telemetry, we need to do 4 things:
-* copy `telemetry.php`
-* edit `telemetry.php` to add your database settings
+* copy `telemetry.php` and `telemetry_settings.php`
+* edit `telemetry_settings.php` to add your database settings
 * create the database
 * enable telemetry
 
@@ -317,14 +317,27 @@ Log into your database using phpMyAdmin or a similar software and import `teleme
 If you see a table called `speedtest_users`, empty, you did it right.
 
 ### Configuring `telemetry.php`
-Open telemetry.php with notepad or a similar text editor.  
-Set your preferred database, ``$db_type="mysql";`` or ``$db_type="sqlite";``  
+Open telemetry_settings.php with notepad or a similar text editor.
+Set your preferred database, ``$db_type="mysql";``, ``$db_type="sqlite";`` or ``$db_type="postgresql";``
+If you choose to use Sqlite3, you must set the path to your database file:
+```php
+$Sqlite_db_file = "../telemetry.sql";
+```
+
 If you choose to use MySQL, you must also add your database credentials:
 ```php
 $MySql_username="USERNAME"; //your database username
 $MySql_password="PASSWORD"; //your database password
 $MySql_hostname="DB_HOSTNAME"; //database address, usually localhost\
 $MySql_databasename="DB_NAME"; //the name of the database where you loaded telemetry.sql
+```
+
+If you choose to use PostgreSQL, you must also add your database credentials:
+```php
+$PostgreSql_username="USERNAME"; //your database username
+$PostgreSql_password="PASSWORD"; //your database password
+$PostgreSql_hostname="DB_HOSTNAME"; //database address, usually localhost
+$PostgreSql_databasename="DB_NAME"; //the name of the database where you loaded telemetry.sql
 ```
 
 ### Enabling telemetry

--- a/telemetry.php
+++ b/telemetry.php
@@ -1,5 +1,5 @@
 <?php
-$db_type="mysql"; //Type db mysql or sqlite
+include_once('telemetry_settings.php');
 
 $ip=($_SERVER['REMOTE_ADDR']);
 $ua=($_SERVER['HTTP_USER_AGENT']);
@@ -11,12 +11,6 @@ $jitter=($_POST["jitter"]);
 $log=($_POST["log"]);
 
 if($db_type=="mysql"){
-        $MySql_username="USERNAME";
-        $MySql_password="PASSWORD";
-        $MySql_hostname="DB_HOSTNAME";
-        $MySql_databasename="DB_NAME";
-
-
     $conn = new mysqli($MySql_hostname, $MySql_username, $MySql_password, $MySql_databasename) or die("1");
     $stmt = $conn->prepare("INSERT INTO speedtest_users (ip,ua,lang,dl,ul,ping,jitter,log) VALUES (?,?,?,?,?,?,?,?)") or die("2");
     $stmt->bind_param("ssssssss",$ip,$ua,$lang,$dl,$ul,$ping,$jitter,$log) or die("3");
@@ -25,10 +19,7 @@ if($db_type=="mysql"){
     $conn->close() or die("6");
 
 }elseif($db_type=="sqlite"){
-
-    $file_db = "../telemetry.sql";
-
-    $conn = new PDO("sqlite:$file_db") or die("1");
+    $conn = new PDO("sqlite:$Sqlite_db_file") or die("1");
     $conn->exec("
         CREATE TABLE IF NOT EXISTS `speedtest_users` (
         `id`    INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -46,6 +37,16 @@ if($db_type=="mysql"){
     $stmt = $conn->prepare("INSERT INTO speedtest_users (ip,ua,lang,dl,ul,ping,jitter,log) VALUES (?,?,?,?,?,?,?,?)") or die("2");
     $stmt->execute(array($ip,$ua,$lang,$dl,$ul,$ping,$jitter,$log)) or die("3");
     $conn = null;
-
+}elseif($db_type=="postgresql"){
+    // Prepare connection parameters for db connection
+    $conn_host = "host=$PostgreSql_hostname";
+    $conn_db = "dbname=$PostgreSql_databasename";
+    $conn_user = "user=$PostgreSql_username";
+    $conn_password = "password=$PostgreSql_password";
+    // Create db connection
+    $conn = new PDO("pgsql:$conn_host;$conn_db;$conn_user;$conn_password") or die("1");
+    $stmt = $conn->prepare("INSERT INTO speedtest_users (ip,ua,lang,dl,ul,ping,jitter,log) VALUES (?,?,?,?,?,?,?,?)") or die("2");
+    $stmt->execute(array($ip,$ua,$lang,$dl,$ul,$ping,$jitter,$log)) or die("3");
+    $conn = null;
 }
 ?>

--- a/telemetry_settings.php
+++ b/telemetry_settings.php
@@ -1,0 +1,20 @@
+<?php
+
+$db_type="postgresql"; //Type of db: "mysql", "sqlite" or "postgresql"
+
+// Sqlite3 settings
+$Sqlite_db_file = "../telemetry.sql";
+
+// Mysql settings
+$MySql_username="USERNAME";
+$MySql_password="PASSWORD";
+$MySql_hostname="DB_HOSTNAME";
+$MySql_databasename="DB_NAME";
+
+// Postgresql settings
+$PostgreSql_username="USERNAME";
+$PostgreSql_password="PASSWORD";
+$PostgreSql_hostname="DB_HOSTNAME";
+$PostgreSql_databasename="DB_NAME";
+
+?>


### PR DESCRIPTION
I've added postgresql database support for telemetry, using PDO similar to the way sqlite3 support was implemented. I moved all database related settings into a separate file so people don't have to modify telemetry.php in order to get everything set up. Updated related documentation.