### PR TITLE
Fixed postgresql schema typo

### DIFF
--- a/telemetry_postgresql.sql
+++ b/telemetry_postgresql.sql
@@ -58,7 +58,7 @@ CREATE TABLE speedtest_users (
 -- Name: speedtest_users_id_seq; Type: SEQUENCE; Schema: public; Owner: speedtest
 --
 
-CREATE SEQUENCE speedtest_users_id_seqd
+CREATE SEQUENCE speedtest_users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE


### PR DESCRIPTION
Not sure how the extra `d` character made it in there, but it causes failures while building the database schema, which in turn breaks storing telemetry results. I've double checked everything works with this change.