### PR TITLE
Make ip use inet type and ul, dl, ping, jitter use real type.

### DIFF
--- a/telemetry_postgresql.sql
+++ b/telemetry_postgresql.sql
@@ -41,13 +41,13 @@ SET default_with_oids = false;
 CREATE TABLE speedtest_users (
     id integer NOT NULL,
     "timestamp" timestamp without time zone DEFAULT now() NOT NULL,
-    ip text NOT NULL,
+    ip inet NOT NULL,
     ua text NOT NULL,
     lang text NOT NULL,
-    dl text,
-    ul text,
-    ping text,
-    jitter text,
+    dl real,
+    ul real,
+    ping real,
+    jitter real,
     log text
 );
 


### PR DESCRIPTION
This allows a query like:

`SELECT AVG(dl) from speedtest_users WHERE ip<<'2620:10b:7000::/64';`

Maybe there are some good reasons for just using text so if thats the case, feel free to reject this :) At least in my basic testing, this works well and allows fancier queries in Postgres.