### PR TITLE
Remove prefix on IPv6-mapped IPv4

### DIFF
--- a/getIP.php
+++ b/getIP.php
@@ -10,6 +10,7 @@
     } else {
         $ip=$_SERVER['REMOTE_ADDR'];
     }
+    $ip=preg_replace("/^::ffff:/", "", $ip);
     $isp="";
     if(isset($_GET["isp"])){
         $json = file_get_contents("https://ipinfo.io/".$ip."/json");


### PR DESCRIPTION
If the speedtest is behind a reverse proxy that is used as an IPv6 endpoint but the PHP is interpreted on an IPv4 server, the forwarded-for header is in an IPv6-mapped IPv4 format (`::ffff:X.Y.Z.W`)
This strips the `::ffff:` part so ipinfo.io can return the correct informations.