### PR TITLE
Handle X-Forwarded-For with multiple hosts

### DIFF
--- a/getIP.php
+++ b/getIP.php
@@ -13,6 +13,7 @@ if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
     $ip = $_SERVER['X-Real-IP'];
 } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
     $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    $ip = preg_replace("/,.*/", "", $ip); # hosts are comma-separated, client is first
 } else {
     $ip = $_SERVER['REMOTE_ADDR'];
 }


### PR DESCRIPTION
When there are multiple proxies, the `X-Forwarded-For` header will be a [comma-separated list](https://en.wikipedia.org/wiki/X-Forwarded-For#Format) of IPs, with the original client first in the list. This change strips the first comma and everything after it, to keep only the client IP.