### PR TITLE
Fixing improper localhost address reporting for ipv4 and v6

### DIFF
--- a/getIP.php
+++ b/getIP.php
@@ -20,11 +20,11 @@ if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
 
 $ip = preg_replace("/^::ffff:/", "", $ip);
 
-if (strpos($ip, '::1') !== false) {
+if ($ip == "::1") { // ::1/128 is the only localhost ipv6 address. there are no others, no need to strpos this
     echo json_encode(['processedString' => $ip . " - localhost ipv6 access", 'rawIspInfo' => ""]);
     die();
 }
-if (strpos($ip, '127.0.0') !== false) {
+if (strpos($ip, '127.') === 0) { //anything within the 127/8 range is localhost ipv4, the ip must start with 127.0
     echo json_encode(['processedString' => $ip . " - localhost ipv4 access", 'rawIspInfo' => ""]);
     die();
 }


### PR DESCRIPTION
Fixed improper reporting of IPV6 and IPV4 localhost addresses, more detailed explanation in comments of modified file.

Basically, 
 for ipv6: the only possible localhost ipv6 is ::1, not any string that contains ::1 like you were doing before.
 for ipv4: any ip in the 127/8 range (from 127.0.0.1 to 127.255.255.254), is a localhost ipv4 address. not just 127.0.0.1 like you were doing before.

edit: commit says 254.254.254, the code is still fine for the correct implementation, it is just checking for prefix 127. which is any ip in 127/8 range, as required.