### PR TITLE
Fix error "Input variables exceeded 1000"

### DIFF
--- a/speedtest_worker.js
+++ b/speedtest_worker.js
@@ -471,6 +471,7 @@ function ulTest(done) {
 					};
 					xhr[i].open("POST", settings.url_ul + url_sep(settings.url_ul) + "r=" + Math.random(), true); // random string to prevent caching
 					xhr[i].setRequestHeader("Content-Encoding", "identity"); // disable compression (some browsers may refuse it, but data is incompressible anyway)
+					xhr[i].setRequestHeader("Content-Type", "application/octet-stream");
 					xhr[i].send(reqsmall);
 				} else {
 					// REGULAR version, no workaround
@@ -504,6 +505,7 @@ function ulTest(done) {
 					// send xhr
 					xhr[i].open("POST", settings.url_ul + url_sep(settings.url_ul) + "r=" + Math.random(), true); // random string to prevent caching
 					xhr[i].setRequestHeader("Content-Encoding", "identity"); // disable compression (some browsers may refuse it, but data is incompressible anyway)
+					xhr[i].setRequestHeader("Content-Type", "application/octet-stream");
 					xhr[i].send(req);
 				}
 			}.bind(this),


### PR DESCRIPTION
Tell PHP not to parse the random data that's POST'ed during upload tests.
The full error logged is `PHP message: PHP Warning:  Unknown: Input variables exceeded 1000. To increase the limit change max_input_vars in php.ini.`.