### PR TITLE
Return null on rawIspInfo instead of '' when data not available

### DIFF
--- a/backend/getIP.php
+++ b/backend/getIP.php
@@ -383,7 +383,7 @@ function sendResponse(
     sendHeaders();
     echo json_encode([
         'processedString' => $processedString,
-        'rawIspInfo' => $rawIspInfo ?: '',
+        'rawIspInfo' => $rawIspInfo ?: null,
     ]);
 }
 


### PR DESCRIPTION
This is to avoid the wrong format of message:


You're testing from: {"processedString":"172.17.0.1 - private IPv4 access","rawIspInfo":""}