### PR TITLE
Add ARM v7 architecture to Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### **User description**
Simply includes ARMv7 in the Docker image build on GitHub. I've been running this without problems on my device for months with multiple versions. It would be good to be able to pull from the official image.


___

### **PR Type**
Enhancement


___

### **Description**
- Add ARM v7 (32-bit) architecture support to Docker image builds

- Extends platform matrix from amd64 and arm64 to include linux/arm/v7

- Enables official Docker image availability for ARM v7 devices


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Docker Build Platforms"] -->|Previously| B["linux/amd64, linux/arm64"]
  A -->|Now| C["linux/amd64, linux/arm64, linux/arm/v7"]
  C -->|Enables| D["ARM v7 Device Support"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Add ARM v7 platform to Docker build matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Updated Docker build platforms configuration to include <code>linux/arm/v7</code><br> <li> Extended multi-architecture support from 2 platforms to 3 platforms<br> <li> Maintains existing amd64 and arm64 architecture builds</ul>


</details>


  </td>
  <td><a href="https://github.com/librespeed/speedtest/pull/741/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

