### PR TITLE
fix: update docker entrypoint sqlite db matching

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -75,7 +75,7 @@ if [[ "$TELEMETRY" == "true" && ("$MODE" == "frontend" || "$MODE" == "standalone
 
   # Override SQLite database path for Docker environment
   # In Docker, we use /database/db.sql which is outside the web-accessible directory
-  sed -i s/\$Sqlite_db_file\ =\ \.\*\'/\$Sqlite_db_file=\'\\\/database\\\/db.sql\'/g /var/www/html/results/telemetry_settings.php
+  sed -i s/\$Sqlite_db_file\ =\ .*\'/\$Sqlite_db_file=\'\\\/database\\\/db.sql\'/g /var/www/html/results/telemetry_settings.php
   sed -i s/\$stats_password\ =\ \'.*\'/\$stats_password\ =\ \'$PASSWORD\'/g /var/www/html/results/telemetry_settings.php
 
   if [ "$ENABLE_ID_OBFUSCATION" == "true" ]; then


### PR DESCRIPTION
### **User description**
As noted in #744, the Docker entrypoint script no longer properly matches the default value of `$Sqlite_db_file` in `results/telemetry_settings.php`.

The default was updated in https://github.com/librespeed/speedtest/commit/13606647968398b62fb41d4c7bba7a4baea8af12:

```diff
- $Sqlite_db_file = '../../speedtest_telemetry.sql';
+ $Sqlite_db_file = __DIR__ . '/speedtest_telemetry.db';
```

The existing sed expression for `$Sqlite_db_file = '\''.*'\''` no longer matches `= '`. This PR updates the expression to match anything from `$Sqlite_db_file = ` to a single quote `'`. As star matching is greedy, this matches through the closing quote:

```shellsession
$ sed s/\$Sqlite_db_file\ =\ \.\*\'/\$Sqlite_db_file=\'\\\/database\\\/db.sql\'/g results/telemetry_settings.php

...
// Sqlite3 settings
$Sqlite_db_file='/database/db.sql';
...
```

With this PR, the Docker entrypoint now correctly matches and replaces the default value for `$Sqlite_db_file`. Closes #744


___

### **PR Type**
Bug fix


___

### **Description**
- Fix Docker entrypoint sed pattern for SQLite database path matching

- Update regex to match new default value format with `__DIR__` constant

- Replace greedy `.*` with `.*'` to properly capture closing quote


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old sed pattern<br/>Sqlite_db_file = '.*'"] -->|"Doesn't match<br/>new format"| B["PHP default<br/>__DIR__ . '/speedtest_telemetry.db'"]
  C["Updated sed pattern<br/>Sqlite_db_file = .*'"] -->|"Correctly matches"| B
  C -->|"Replaces with"| D["Docker path<br/>/database/db.sql"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Fix SQLite database path sed pattern matching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/entrypoint.sh

<ul><li>Updated sed expression for <code>$Sqlite_db_file</code> variable substitution<br> <li> Changed pattern from <code>\'.*\'</code> to <code>\.\*\'</code> to match new PHP default format<br> <li> Ensures Docker entrypoint correctly replaces SQLite database path <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/librespeed/speedtest/pull/746/files#diff-4f5cabe26761257a4d685a6edc7a43e0fe0f78762f50eeb48530f2bd3b3ee7ca">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

