### PR TITLE
fix: return client IPv6 address via cloudflared

### DIFF
--- a/backend/getIP_util.php
+++ b/backend/getIP_util.php
@@ -1,21 +1,55 @@
 <?php
 
 /**
+ * Normalize and validate an IP address candidate from a request header.
+ *
+ * Trims whitespace, takes the first comma-separated token (for XFF-like
+ * headers that may contain a chain of addresses), and validates the result
+ * with filter_var().
+ *
+ * @param string $raw       Raw header value.
+ * @param int    $extraFlags Additional FILTER_FLAG_* flags (e.g. FILTER_FLAG_IPV6).
+ *
+ * @return string|false The validated IP string, or false on failure.
+ */
+function normalizeCandidateIp($raw, $extraFlags = 0)
+{
+    $ip = trim($raw);
+    // For XFF-like values, take the first address before a comma.
+    if (($pos = strpos($ip, ',')) !== false) {
+        $ip = trim(substr($ip, 0, $pos));
+    }
+    if ($ip === '') {
+        return false;
+    }
+    return filter_var($ip, FILTER_VALIDATE_IP, $extraFlags);
+}
+
+/**
  * @return string
  */
-function getClientIp() {
+function getClientIp()
+{
+    // Cloudflare IPv6 header — must be a valid IPv6 address.
     if (!empty($_SERVER['HTTP_CF_CONNECTING_IPV6'])) {
-        $ip = $_SERVER['HTTP_CF_CONNECTING_IPV6'];
-    } elseif (!empty($_SERVER['HTTP_CLIENT_IP'])) {
-        $ip = $_SERVER['HTTP_CLIENT_IP'];
-    } elseif (!empty($_SERVER['HTTP_X_REAL_IP'])) {
-        $ip = $_SERVER['HTTP_X_REAL_IP'];
-    } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-        $ip = preg_replace('/,.*/', '', $ip); # hosts are comma-separated, client is first
-    } else {
-        $ip = $_SERVER['REMOTE_ADDR'];
+        $ip = normalizeCandidateIp($_SERVER['HTTP_CF_CONNECTING_IPV6'], FILTER_FLAG_IPV6);
+        if ($ip !== false) {
+            return preg_replace('/^::ffff:/', '', $ip);
+        }
     }
-
-    return preg_replace('/^::ffff:/', '', $ip);
+    // Other forwarding / proxy headers — accept any valid IP.
+    foreach (['HTTP_CLIENT_IP', 'HTTP_X_REAL_IP', 'HTTP_X_FORWARDED_FOR'] as $header) {
+        if (!empty($_SERVER[$header])) {
+            $ip = normalizeCandidateIp($_SERVER[$header]);
+            if ($ip !== false) {
+                return preg_replace('/^::ffff:/', '', $ip);
+            }
+        }
+    }
+    // Fallback: REMOTE_ADDR is set by the web server and is always a single IP.
+    $ip = normalizeCandidateIp($_SERVER['REMOTE_ADDR'] ?? '');
+    if ($ip !== false) {
+        return preg_replace('/^::ffff:/', '', $ip);
+    }
+    return $_SERVER['REMOTE_ADDR'] ?? '';
 }


### PR DESCRIPTION
The `cloudflared` reverse proxy populates the `X-Forwarded-For` header for origin IPv4 addresses, however origin IPv6 addresses are added in a different header: `Cf-Connecting-Ipv6`. This updates the `getIP.php` mechanism to retrieve the value of this header and to prefer it over other client IP headers (in both cases only if the `Cf-Connecting-Ipv6` header exists and is not empty).

A (sanitised) example of request headers passed by `cloudflared`:

```json
{
  "headers": {
    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
    "Accept-Encoding": "gzip, br",
    "Accept-Language": "en-AU,en;q=0.9",
    "Cdn-Loop": "cloudflare; loops=1",
    "Cf-Connecting-Ip": "254.252.239.103",
    "Cf-Connecting-Ipv6": "2403:580c:<redacted>",
    "Cf-Ipcountry": "AU",
    "Cf-Pseudo-Ipv4": "254.252.239.103",
    "Cf-Ray": "9d754acd5f8bd71b-BNE",
    "Cf-Visitor": "{\"scheme\":\"https\"}",
    "Cf-Warp-Tag-Id": "<redacted>",
    "Connection": "keep-alive",
    "Host": "<redacted>",
    "Priority": "u=0, i",
    "Sec-Fetch-Dest": "document",
    "Sec-Fetch-Mode": "navigate",
    "Sec-Fetch-Site": "none",
    "Upgrade-Insecure-Requests": "1",
    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3 Safari/605.1.15",
    "X-Forwarded-For": "254.252.239.103",
    "X-Forwarded-Proto": "https"
  }
}
```