### PR TITLE
fix(docker): raise PHP post_max_size for default 20MB upload chunks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ RUN install-php-extensions iconv gd pdo pdo_mysql pdo_pgsql pgsql \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
-RUN scan_dir="$(php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')" \
-    && [ -n "$scan_dir" ] \
-    && install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini" \
-    && rm /tmp/librespeed-php.ini
+# PHP_INI_DIR is set by the official php:8-apache image to /usr/local/etc/php
+# and has been stable across PHP majors. Using the env var documents intent
+# and follows any future upstream change to the path automatically.
+COPY docker/librespeed-php.ini ${PHP_INI_DIR}/conf.d/99-librespeed.ini
 
 # Prepare files and folders
 RUN mkdir -p /speedtest/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ RUN install-php-extensions iconv gd pdo pdo_mysql pdo_pgsql pgsql \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
+RUN scan_dir="$(php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')" \
+    && [ -n "$scan_dir" ] \
+    && install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini" \
+    && rm /tmp/librespeed-php.ini
+
 # Prepare files and folders
 RUN mkdir -p /speedtest/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ RUN install-php-extensions iconv gd pdo pdo_mysql pdo_pgsql pgsql \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# PHP_INI_DIR is set by the official php:8-apache image to /usr/local/etc/php
-# and has been stable across PHP majors. Using the env var documents intent
-# and follows any future upstream change to the path automatically.
 COPY docker/librespeed-php.ini ${PHP_INI_DIR}/conf.d/99-librespeed.ini
 
 # Prepare files and folders

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -24,6 +24,12 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
+COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
+RUN scan_dir="$(/usr/bin/php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')" \
+    && [ -n "$scan_dir" ] \
+    && install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini" \
+    && rm /tmp/librespeed-php.ini
+
 # Prepare files and folders
 RUN mkdir -p /speedtest/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -24,11 +24,22 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
+# This image has two PHP installs: the FROM php:8-alpine binary (conf.d at
+# /usr/local/etc/php/conf.d) and the apk-installed php-apache2 (conf.d at
+# /etc/phpXX/conf.d). mod_php uses the apk one — glob /etc/php*/conf.d to
+# find it without pinning the PHP major.
 COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
-RUN scan_dir="$(/usr/bin/php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')" \
-    && [ -n "$scan_dir" ] \
-    && install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini" \
-    && rm /tmp/librespeed-php.ini
+RUN set -eu; \
+    scan_dir=""; \
+    for d in /etc/php*/conf.d; do \
+      [ -d "$d" ] && scan_dir="$d" && break; \
+    done; \
+    if [ -z "$scan_dir" ]; then \
+      echo "ERROR: no /etc/php*/conf.d directory found; apk php-apache2 install layout may have changed" >&2; \
+      exit 1; \
+    fi; \
+    install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini"; \
+    rm /tmp/librespeed-php.ini
 
 # Prepare files and folders
 RUN mkdir -p /speedtest/

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,11 +20,22 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
+# This image has two PHP installs: the FROM php:8-alpine binary (conf.d at
+# /usr/local/etc/php/conf.d) and the apk-installed php-apache2 (conf.d at
+# /etc/phpXX/conf.d). mod_php uses the apk one — glob /etc/php*/conf.d to
+# find it without pinning the PHP major.
 COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
-RUN scan_dir="$(/usr/bin/php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')" \
-    && [ -n "$scan_dir" ] \
-    && install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini" \
-    && rm /tmp/librespeed-php.ini
+RUN set -eu; \
+    scan_dir=""; \
+    for d in /etc/php*/conf.d; do \
+      [ -d "$d" ] && scan_dir="$d" && break; \
+    done; \
+    if [ -z "$scan_dir" ]; then \
+      echo "ERROR: no /etc/php*/conf.d directory found; apk php-apache2 install layout may have changed" >&2; \
+      exit 1; \
+    fi; \
+    install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini"; \
+    rm /tmp/librespeed-php.ini
 
 # Prepare files and folders
 RUN mkdir -p /speedtest/

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,6 +20,12 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
+COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
+RUN scan_dir="$(/usr/bin/php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')" \
+    && [ -n "$scan_dir" ] \
+    && install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini" \
+    && rm /tmp/librespeed-php.ini
+
 # Prepare files and folders
 RUN mkdir -p /speedtest/
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,10 +20,8 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
-# This image has two PHP installs: the FROM php:8-alpine binary (conf.d at
-# /usr/local/etc/php/conf.d) and the apk-installed php-apache2 (conf.d at
-# /etc/phpXX/conf.d). mod_php uses the apk one — glob /etc/php*/conf.d to
-# find it without pinning the PHP major.
+# Alpine installs PHP from apk; php-apache2 reads /etc/phpXX/conf.d.
+# Use the versioned apk conf.d without pinning the PHP major.
 COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
 RUN set -eu; \
     scan_dir=""; \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,7 +20,7 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
-# Use PHP's scan dir without pinning the apk PHP major.
+# Install the ini into the scan dir PHP itself reports.
 COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
 RUN set -eu; \
     scan_dir="$(php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')"; \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,19 +20,15 @@ RUN apk add --quiet --no-cache \
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log
 
-# Alpine installs PHP from apk; php-apache2 reads /etc/phpXX/conf.d.
-# Use the versioned apk conf.d without pinning the PHP major.
+# Use PHP's scan dir without pinning the apk PHP major.
 COPY docker/librespeed-php.ini /tmp/librespeed-php.ini
 RUN set -eu; \
-    scan_dir=""; \
-    for d in /etc/php*/conf.d; do \
-      [ -d "$d" ] && scan_dir="$d" && break; \
-    done; \
+    scan_dir="$(php -r 'echo rtrim(PHP_CONFIG_FILE_SCAN_DIR);')"; \
     if [ -z "$scan_dir" ]; then \
-      echo "ERROR: no /etc/php*/conf.d directory found; apk php-apache2 install layout may have changed" >&2; \
+      echo "ERROR: PHP_CONFIG_FILE_SCAN_DIR is empty" >&2; \
       exit 1; \
     fi; \
-    install -D -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini"; \
+    install -m 0644 /tmp/librespeed-php.ini "$scan_dir/99-librespeed.ini"; \
     rm /tmp/librespeed-php.ini
 
 # Prepare files and folders

--- a/docker/librespeed-php.ini
+++ b/docker/librespeed-php.ini
@@ -1,0 +1,18 @@
+; LibreSpeed-recommended PHP override.
+;
+; speedtest_worker.js uploads in 20 MB chunks by default
+; (xhr_ul_blob_megabytes: 20). PHP's stock post_max_size = 8M rejects
+; every chunk: PHP emits a "POST Content-Length ... exceeds the
+; limit" startup warning and prevents empty.php from sending its
+; response headers (Cache-Control, Pragma, Connection, and CORS
+; under ?cors).
+;
+; The upload throughput number itself is unaffected — the worker
+; reads bytes-on-wire from xhr.upload.onprogress, not the response
+; body — but the response from empty.php is otherwise malformed.
+;
+; 32M is the next round number above the worker's 20M default; it
+; leaves headroom for operators who tune xhr_ul_blob_megabytes
+; upwards.
+
+post_max_size = 32M

--- a/docker/librespeed-php.ini
+++ b/docker/librespeed-php.ini
@@ -1,18 +1,5 @@
-; LibreSpeed-recommended PHP override.
-;
-; speedtest_worker.js uploads in 20 MB chunks by default
-; (xhr_ul_blob_megabytes: 20). PHP's stock post_max_size = 8M rejects
-; every chunk: PHP emits a "POST Content-Length ... exceeds the
-; limit" startup warning and prevents empty.php from sending its
-; response headers (Cache-Control, Pragma, Connection, and CORS
-; under ?cors).
-;
-; The upload throughput number itself is unaffected — the worker
-; reads bytes-on-wire from xhr.upload.onprogress, not the response
-; body — but the response from empty.php is otherwise malformed.
-;
-; 32M is the next round number above the worker's 20M default; it
-; leaves headroom for operators who tune xhr_ul_blob_megabytes
-; upwards.
+; speedtest_worker.js defaults xhr_ul_blob_megabytes to 20.
+; PHP's stock post_max_size = 8M rejects those upload chunks before
+; empty.php can send its headers. 32M leaves modest headroom.
 
 post_max_size = 32M


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Docker PHP upload limits for 20MB upload chunks
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Fixes #797 (Default PHP upload limits reject 20 MB chunks).

`speedtest_worker.js` uploads in 20 MB chunks by default (`xhr_ul_blob_megabytes: 20`). PHP's stock `post_max_size = 8M` is still too low for that request size.

Current `master` after #800 behaves like this:

- Debian image: the 20 MB POST still writes a PHP warning into `/backend/empty.php?cors=true`, then `header()` calls fail. The response body is non-empty and the expected CORS/cache headers are missing.
- Alpine image: the response stays empty after #800, but Apache still logs the same `POST Content-Length ... exceeds the limit of 8388608 bytes` warning.

## Fix

Add `docker/librespeed-php.ini`:

```ini
post_max_size = 32M
```

Install it into PHP's scanned config directory in both images:

- `Dockerfile`: `${PHP_INI_DIR}/conf.d/99-librespeed.ini`
- `Dockerfile.alpine`: `PHP_CONFIG_FILE_SCAN_DIR/99-librespeed.ini`

`32M` is just above the worker's default 20 MB upload chunk.

## Verified

Built both Docker variants from this branch and tested through Apache:

```sh
head -c 20971520 /dev/zero | curl -X POST --data-binary @- \
  'http://127.0.0.1:{port}/backend/empty.php?cors=true'
```

Both Debian and Alpine returned `HTTP 200` with `Content-Length: 0`. CORS/cache headers were present, and logs had no PHP upload-limit or header warnings.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Add a PHP ini override to allow 20MB upload chunks without warnings
• Install the override into PHP conf.d for both Debian and Alpine images
• Prevent header/CORS/cache responses from being broken by PHP upload-limit errors
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  D1["Dockerfile (Debian image)"] --> INI["docker/librespeed-php.ini"] --> PHPD["PHP conf.d (Debian)"] --> PHPR["PHP runtime"] --> EP["backend/empty.php"]
  D2["Dockerfile.alpine (Alpine image)"] --> INI --> PHPA["PHP conf.d (Alpine)"] --> PHPR
  SW["speedtest_worker.js"] -->|"20MB POST chunks"| EP
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Reduce default upload chunk size in the worker</b></summary>

- ➕ Avoids server-side limit changes entirely
- ➕ May reduce memory pressure on constrained servers
- ➖ Potentially reduces upload test accuracy/throughput due to more overhead
- ➖ Changes client behavior for all deployments, not just Docker images

</details>

<details>
<summary><b>2. Document runtime override (mount custom ini / set php.ini in compose)</b></summary>

- ➕ Lets operators choose limits without image changes
- ➕ No build-time logic required in Dockerfiles
- ➖ Does not fix the default OOTB Docker experience
- ➖ Easy for users to miss; issue persists unless they read docs

</details>

<details>
<summary><b>3. Adjust Apache/PHP request handling (e.g., per-vhost php_admin_value)</b></summary>

- ➕ Can scope limits to only the speedtest endpoints
- ➕ Keeps the base php.ini closer to upstream defaults
- ➖ More Apache-config complexity and higher risk of portability issues
- ➖ Harder to reason about across Debian vs Alpine packaging differences

</details>

**Recommendation:** Keep the PR’s approach: ship a small conf.d ini override in both Docker images. It fixes the broken default behavior for the worker’s 20MB uploads without changing client semantics, and it’s straightforward to validate (a single 20MB POST to empty.php). Alternatives either change core test behavior or rely on users applying manual overrides.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>librespeed-php.ini</strong> <code>Add PHP post_max_size override for 20MB uploads</code> <code>+5/-0</code></summary>

<br/>

>Add PHP post_max_size override for 20MB uploads
>
><pre>
>• Introduces a custom ini file setting post_max_size = 32M with comments explaining the 20MB upload-chunk requirement. This prevents upload-size warnings that can corrupt/precede header output.
></pre>
>
><a href='https://github.com/librespeed/speedtest/pull/798/files#diff-f665dde9d7974a2e2f0e527615270699638fcd25e859a2d8931941275aff498e'>docker/librespeed-php.ini</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>Dockerfile</strong> <code>Copy LibreSpeed PHP ini into php:8-apache conf.d</code> <code>+5/-0</code></summary>

<br/>

>Copy LibreSpeed PHP ini into php:8-apache conf.d
>
><pre>
>• Adds a COPY step to install docker/librespeed-php.ini into ${PHP_INI_DIR}/conf.d as 99-librespeed.ini. This raises PHP request size limits for default upload chunks in the Debian-based image.
></pre>
>
><a href='https://github.com/librespeed/speedtest/pull/798/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557'>Dockerfile</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>Dockerfile.alpine</strong> <code>Install LibreSpeed PHP ini into Alpine PHP scan directory</code> <code>+11/-0</code></summary>

<br/>

>Install LibreSpeed PHP ini into Alpine PHP scan directory
>
><pre>
>• Copies the ini to a temp location, resolves PHP_CONFIG_FILE_SCAN_DIR at build time, and installs 99-librespeed.ini into the scanned conf.d directory. This ensures the Alpine image loads the higher post_max_size setting.
></pre>
>
><a href='https://github.com/librespeed/speedtest/pull/798/files#diff-f865864730d7062c04cc13b1b85ba03ed5dbef3fa02fcb50b87d9117d0af1f4e'>Dockerfile.alpine</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>