### PR TITLE
Drop FROM php:8-alpine in favor of FROM alpine:3.23 (~55% smaller image)

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,6 +2,7 @@ FROM alpine:3.23
 RUN apk add --quiet --no-cache \
     bash \
     apache2 \
+    ca-certificates \
     php \
     php-apache2 \
     php-ctype \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,8 @@
-FROM php:8-alpine
+FROM alpine:3.23
 RUN apk add --quiet --no-cache \
     bash \
     apache2 \
+    php \
     php-apache2 \
     php-ctype \
     php-phar \
@@ -14,12 +15,6 @@ RUN apk add --quiet --no-cache \
     php-pgsql \
     php-session \
     php-sqlite3
-
-# # use docker-php-extension-installer for automatically get the right packages installed
-# ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-
-# # Install extensions
-# RUN install-php-extensions iconv gd pdo pdo_mysql pdo_pgsql pgsql
 
 RUN ln -sf /dev/stdout /var/log/apache2/access.log && \
     ln -sf /dev/stderr /var/log/apache2/error.log


### PR DESCRIPTION
Fixes #799.

Replace `FROM php:8-alpine` with `FROM alpine:3.23` in `Dockerfile.alpine` and install PHP entirely via apk. See #799 for the full context. Short version: the FROM image's `/usr/local/bin/php` is never used by Apache (mod_php loads from the apk packages instead), and the FROM image also carries PHP source/build artifacts the runtime doesn't need.

## Change

```diff
-FROM php:8-alpine
+FROM alpine:3.23
 RUN apk add --quiet --no-cache \
     bash \
     apache2 \
+    php \
     php-apache2 \
     php-ctype \
     ...
```

The dead `docker-php-extension-installer` comment block also goes; it never applied to the alpine variant.

## Image size

```
libsp-old:alpine  227 MB  (master HEAD)
libsp-exp:alpine  102 MB  (this PR)
```

The savings come from dropping the unused `/usr/local/bin/php` binary plus the `/usr/src/php` headers and build artifacts that the docker-library `php:8-alpine` image carries. ~55% smaller.

## Verification

Inside the new image:

```
$ ls /usr/local/bin/php /usr/bin/php* 2>/dev/null
lrwxrwxrwx ... /usr/bin/php -> php84
-rwxr-xr-x ... /usr/bin/php84
$ command -v php
/usr/bin/php
$ ls /usr/lib/apache2/mod_php*.so
/usr/lib/apache2/mod_php84.so
```

One PHP install, no FROM-image leftovers, and mod_php is still served by the same `php-apache2` package — which on alpine:3.23 resolves to php84, same major as master's `FROM php:8-alpine`.

Full Playwright e2e suite passes against this image: 12/12, 22.4s. Specs: classic-standalone-regression, design-switch, modes, title-special-chars across standalone/backend/frontend/dual configs.

## Note on PHP version

`alpine:3.23`'s `php-apache2` meta resolves to `php84-apache2`, matching the PHP major that master's `FROM php:8-alpine` lands on today. No version regression and no need to pin a versioned package. Earlier alpine releases (3.21, 3.22) defaulted to php83; if a future Alpine bump shifts the default again, pinning `php84-*` explicitly is the escape hatch.

## Dependabot

`.github/dependabot.yml`'s docker ecosystem at `/` auto-discovers FROM lines. After this PR, Dependabot drops `php:8-alpine` and picks up `alpine:3.23`. No config change needed. One subtle shift: Alpine bumps now carry the implicit risk of a PHP major bump when the apk meta shifts — see the PHP-version note above for the lock-down option.
