### PR TITLE
Fix typos in documentation and a code comment

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -103,7 +103,7 @@ $PostgreSql_hostname="DB_HOSTNAME"; //database address, usually localhost
 $PostgreSql_databasename="DB_NAME"; //the name of the database where you loaded telemetry_postgresql.sql
 ```
 
-Ifyou chose to use MSSQL, you must set your database credentials:
+If you chose to use MSSQL, you must set your database credentials:
 
 ```php
 $MsSql_server = 'DB_HOSTNAME';
@@ -468,7 +468,7 @@ __Advanced parameters:__ (Seriously, don't change these unless you know what you
 * __useMebibits__: use mebibits/s instead of megabits/s for the speeds
   * Default: `false`
 * __overheadCompensationFactor__: compensation for HTTP and network overhead. Default value assumes typical MTUs used over the Internet. You might want to change this if you're using this in your internal network with different MTUs, or if you're using IPv6 instead of IPv4.
-  * Default: `1.06` probably a decent estimate for all overhead. This was measured empirically by comparing the measured speed and the speed reported by my the network adapter.
+  * Default: `1.06` probably a decent estimate for all overhead. This was measured empirically by comparing the measured speed and the speed reported by my network adapter.
   * `1048576/925000`: old default value. This is probably too high.
   * `1.0513`: HTTP+TCP+IPv6+ETH, over the Internet (empirically tested, not calculated)
   * `1.0369`: Alternative value for HTTP+TCP+IPv4+ETH, over the Internet (empirically tested, not calculated)

--- a/doc_docker.md
+++ b/doc_docker.md
@@ -63,7 +63,7 @@ Here's a list of additional environment variables available in this mode:
 * __`SERVER_LIST_URL`__: When set, both frontend designs load their server list from this URL instead of the generated or mounted `server-list.json`. This is useful if you want the containerized frontend to consume a remote shared server list.
 * __`TELEMETRY`__: Whether to enable telemetry or not. If enabled, you maybe want your data to be persisted. See below. Default value: `false`
 * __`ENABLE_ID_OBFUSCATION`__: When set to true with telemetry enabled, test IDs are obfuscated, to avoid exposing the database internal sequential IDs. Default value: `false`
-* __`OBFUSCATION_SALT`__: The salt string that is used to obfuscate the test IDs. The format shoud be a 2 byte hex string (e.g. `0x1234abcd`). If not specified, a random one will be generated.
+* __`OBFUSCATION_SALT`__: The salt string that is used to obfuscate the test IDs. The format should be a 2 byte hex string (e.g. `0x1234abcd`). If not specified, a random one will be generated.
 * __`REDACT_IP_ADDRESSES`__: When set to true with telemetry enabled, IP addresses and hostnames are redacted from the collected telemetry, for better privacy. Default value: `false`
 * __`DB_TYPE`__: When set to one of the supported DB-Backends it will use this instead of the default sqlite database backend. TELEMETRY has to be set to `true`. Also you have to create the database as described in [doc.md](doc.md#creating-the-database). Supported backend types are:
   * sqlite - no additional settings required

--- a/speedtest.js
+++ b/speedtest.js
@@ -66,7 +66,7 @@ Speedtest.prototype = {
    * - parameter: string with the name of the parameter that you want to set
    * - value: new value for the parameter
    *
-   * Invalid values or nonexistant parameters will be ignored by the speed test worker.
+   * Invalid values or nonexistent parameters will be ignored by the speed test worker.
    */
   setParameter: function(parameter, value) {
     if (this._state == 3)


### PR DESCRIPTION
Four small typo fixes (docs + one source comment):

- `doc.md` — `Ifyou chose to use MSSQL` → `If you chose to use MSSQL` (missing space).
- `doc.md` — `reported by my the network adapter` → `reported by my network adapter` (duplicate word).
- `speedtest.js` — `nonexistant` → `nonexistent` (comment spelling).
- `doc_docker.md` — `The format shoud be` → `The format should be`.

No code/behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)