### PR TITLE
Fix upload speed inflation from HTTP errors + document server body size limit

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -60,6 +60,20 @@ Let's install the speed test.
 
 Put all files on your web server via FTP or by copying them directly. You can install it in the root, or in a subdirectory.
 
+**Web server upload limit:** The upload test sends POST requests up to 20 MB (configurable with `xhr_ul_blob_megabytes`). Without proper configuration, the server will reject these with HTTP 413, causing wildly inaccurate upload speeds. Configure your web server to accept large request bodies:
+
+Nginx:
+```
+client_max_body_size 128m;
+```
+
+Apache:
+```
+LimitRequestBody 134217728
+```
+
+IIS: Set `maxAllowedContentLength` in `web.config`.
+
 __Important:__ The speed test needs write permissions in the installation folder!
 
 #### ipinfo.io

--- a/doc.md
+++ b/doc.md
@@ -72,7 +72,16 @@ Apache:
 LimitRequestBody 134217728
 ```
 
-IIS: Set `maxAllowedContentLength` in `web.config`.
+IIS: Add the following to `web.config` (value is in bytes):
+```xml
+<system.webServer>
+  <security>
+    <requestFiltering>
+      <requestLimits maxAllowedContentLength="134217728" />
+    </requestFiltering>
+  </security>
+</system.webServer>
+```
 
 __Important:__ The speed test needs write permissions in the installation folder!
 

--- a/speedtest_worker.js
+++ b/speedtest_worker.js
@@ -502,9 +502,20 @@ function ulTest(done) {
 							prevLoaded = event.loaded;
 						}.bind(this);
 						xhr[i].upload.onload = function() {
-							// this stream sent all the garbage data, start again
-							tverb("ul stream finished " + i);
-							testStream(i, 0);
+							// check HTTP status - non-2xx means server rejected the request (e.g. 413 body too large)
+							if (xhr[i].status >= 200 && xhr[i].status < 300) {
+								// this stream sent all the garbage data, start again
+								tverb("ul stream finished " + i);
+								testStream(i, 0);
+							} else {
+								tverb("ul stream failed with HTTP " + xhr[i].status + " " + i);
+								if (settings.xhr_ignoreErrors === 0) failed = true; //abort
+								try {
+									xhr[i].abort();
+								} catch (e) {}
+								delete xhr[i];
+								if (settings.xhr_ignoreErrors === 1) testStream(i, 0); //restart stream
+							}
 						}.bind(this);
 						xhr[i].upload.onerror = function() {
 							tverb("ul stream failed " + i);

--- a/speedtest_worker.js
+++ b/speedtest_worker.js
@@ -502,20 +502,9 @@ function ulTest(done) {
 							prevLoaded = event.loaded;
 						}.bind(this);
 						xhr[i].upload.onload = function() {
-							// check HTTP status - non-2xx means server rejected the request (e.g. 413 body too large)
-							if (xhr[i].status >= 200 && xhr[i].status < 300) {
-								// this stream sent all the garbage data, start again
-								tverb("ul stream finished " + i);
-								testStream(i, 0);
-							} else {
-								tverb("ul stream failed with HTTP " + xhr[i].status + " " + i);
-								if (settings.xhr_ignoreErrors === 0) failed = true; //abort
-								try {
-									xhr[i].abort();
-								} catch (e) {}
-								delete xhr[i];
-								if (settings.xhr_ignoreErrors === 1) testStream(i, 0); //restart stream
-							}
+							// this stream sent all the garbage data, start again
+							tverb("ul stream finished " + i);
+							testStream(i, 0);
 						}.bind(this);
 						xhr[i].upload.onerror = function() {
 							tverb("ul stream failed " + i);
@@ -525,6 +514,16 @@ function ulTest(done) {
 							} catch (e) {}
 							delete xhr[i];
 							if (settings.xhr_ignoreErrors === 1) testStream(i, 0); //restart stream
+						}.bind(this);
+						xhr[i].onload = function() {
+							// check HTTP status after full response is available
+							if (xhr[i].status >= 200 && xhr[i].status < 300) return;
+							tverb("ul stream failed with HTTP " + xhr[i].status + " " + i);
+							if (settings.xhr_ignoreErrors === 0) failed = true; //abort
+							try {
+								xhr[i].abort();
+							} catch (e) {}
+							delete xhr[i];
 						}.bind(this);
 						// send xhr
 						xhr[i].open("POST", settings.url_ul + url_sep(settings.url_ul) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random(), true); // random string to prevent caching

--- a/speedtest_worker.js
+++ b/speedtest_worker.js
@@ -502,28 +502,28 @@ function ulTest(done) {
 							prevLoaded = event.loaded;
 						}.bind(this);
 						xhr[i].upload.onload = function() {
-							// this stream sent all the garbage data, start again
-							tverb("ul stream finished " + i);
-							testStream(i, 0);
+							// body uploaded, but response not yet available.
+							// xhr.onload below handles the full lifecycle.
 						}.bind(this);
 						xhr[i].upload.onerror = function() {
 							tverb("ul stream failed " + i);
-							if (settings.xhr_ignoreErrors === 0) failed = true; //abort
-							try {
-								xhr[i].abort();
-							} catch (e) {}
+							if (settings.xhr_ignoreErrors === 0) failed = true;
+							try { x.abort(); } catch (e) {}
 							delete xhr[i];
-							if (settings.xhr_ignoreErrors === 1) testStream(i, 0); //restart stream
+							if (settings.xhr_ignoreErrors === 1) testStream(i, 0);
 						}.bind(this);
 						xhr[i].onload = function() {
-							// check HTTP status after full response is available
-							if (xhr[i].status >= 200 && xhr[i].status < 300) return;
-							tverb("ul stream failed with HTTP " + xhr[i].status + " " + i);
-							if (settings.xhr_ignoreErrors === 0) failed = true; //abort
-							try {
-								xhr[i].abort();
-							} catch (e) {}
-							delete xhr[i];
+							// response complete — check status on captured x, not xhr[i]
+							if (x.status >= 200 && x.status < 300) {
+								tverb("ul stream finished " + i);
+								testStream(i, 0);
+							} else {
+								tverb("ul stream failed with HTTP " + x.status + " " + i);
+								if (settings.xhr_ignoreErrors === 0) failed = true;
+								try { x.abort(); } catch (e) {}
+								delete xhr[i];
+								if (settings.xhr_ignoreErrors === 1) testStream(i, 0);
+							}
 						}.bind(this);
 						// send xhr
 						xhr[i].open("POST", settings.url_ul + url_sep(settings.url_ul) + (settings.mpot ? "cors=true&" : "") + "r=" + Math.random(), true); // random string to prevent caching


### PR DESCRIPTION
   ## What
   - `speedtest_worker.js`: `xhr.upload.onload` now checks HTTP status before restarting the upload stream. Non-2xx responses (e.g. HTTP 413 from undersized `client_max_body_size`) are
 treated as failures instead of inflating upload speed measurements.
   - `doc.md`: added explicit nginx/Apache/IIS config examples for `client_max_body_size` / `LimitRequestBody` to prevent HTTP 413 errors on 20 MB upload blobs.

   ## Why
   Server returning 413 (body too large) caused `onload` to fire instantly with the worker interpreting it as a successful upload, reporting impossible speeds (7-10 Gbps on gigabit LAN).
 Fixes both the symptom (code) and the root cause (docs).
 
 Closes #819